### PR TITLE
Fixes invalid merge when not on the master branch

### DIFF
--- a/lib/redmine_pulls/patches/adapters/git_adapter_helper.rb
+++ b/lib/redmine_pulls/patches/adapters/git_adapter_helper.rb
@@ -56,8 +56,14 @@ module RedminePulls
           end
 
           def merge(commit_base, commit_head, options = {})
-            # $ git read-tree -i -m branch1 branch2
+            old_ref = revision(commit_base)
+            base_ref = merge_base(commit_base, commit_head)
+
+            git_cmd_output(%w|read-tree --empty|)
+
+            # $ git read-tree -i -m base branch1 branch2
             cmd_args = %w|read-tree -i -m|
+            cmd_args << base_ref
             cmd_args << commit_base
             cmd_args << commit_head
             git_cmd_output(cmd_args)
@@ -84,6 +90,7 @@ module RedminePulls
             cmd_args = %w|update-ref|
             cmd_args << "refs/heads/#{commit_base}"
             cmd_args << commit_hash
+            cmd_args << old_ref
             git_cmd_output(cmd_args)
 
             commit_hash


### PR DESCRIPTION
# Description
I enhanced `read-tree` git command to make a three way merge in order to include changes in the base branch. Also, I added "old value" ref so the merge will be applied only if the base branch current value correspond to the "old value".

Fixes #31

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

1. You can "seed" your repository by running this helper command:
```bash
git checkout master && git pull --rebase && git checkout -b test1-1 && echo Hello world >> test1-1.txt && git add test1-1.txt && git commit -m "test1-1.txt" && git push --set-upstream origin test1-1 && git checkout -b test1-2 && echo Hello universe >> test1-2.txt && git add test1-2.txt && git commit -m "test1-2.txt" && git push --set-upstream origin test1-2
```
2. Create a new pull request from branch `test1-2` to branch `test1-1`.
3. Accept and merge the pull request.
4. Validate the merge in the `Repository` section and selecting the branch `test1-1`.
5. I expect you to see all files from both branches.

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
