### PR TITLE
Correct the reviewer count on a pull request sidebar

### DIFF
--- a/app/views/pull_reviewers/_reviewers.html.erb
+++ b/app/views/pull_reviewers/_reviewers.html.erb
@@ -4,6 +4,6 @@
   </div>
 <% end %>
 
-<h3><%= l(:label_reviewers) %> (<%= pull.reviews.size %>)</h3>
+<h3><%= l(:label_reviewers) %> (<%= pull.reviews.count %>)</h3>
 
 <%= reviewers_list(pull) %>


### PR DESCRIPTION
# Description

When a PR doesn't have any reviewers, a wrong reviewer count is displayed in the sidebar of a pull request.

Fixes #30

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Manually tested.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
