### PR TITLE
Ability to define a pull request template for the description

### DIFF
--- a/app/controllers/pulls_controller.rb
+++ b/app/controllers/pulls_controller.rb
@@ -197,6 +197,8 @@ class PullsController < ApplicationController
     @pull.commit_base = default_branch
     @pull.commit_head = default_branch
 
+    @pull.description = default_pull_description(@pull)
+
     attrs = (params[:pull] || {}).deep_dup
     @pull.safe_attributes = attrs
   end

--- a/app/helpers/pulls_helper.rb
+++ b/app/helpers/pulls_helper.rb
@@ -18,6 +18,14 @@ module PullsHelper
     render :template => 'pulls/no_repository', :status => 404
   end
 
+  def default_pull_description(pull)
+    default_branch = pull.repository.default_branch
+    template_extension = Setting.text_formatting == 'markdown' ? 'md' : Setting.text_formatting;
+    template_file = ".redmine/PULL_REQUEST_TEMPLATE.#{template_extension}"
+
+    pull.repository.cat(template_file, default_branch)
+  end
+
   # Returns an array of users that are proposed as watchers
   # on the new issue form
   def users_for_new_pull_reviewers(pull)

--- a/test/functional/pulls_controller_test.rb
+++ b/test/functional/pulls_controller_test.rb
@@ -35,6 +35,15 @@ class PullsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  def test_get_new_with_pull_request_template
+    Repository.any_instance.stubs(:cat).returns('Pull request template example')
+
+    get :new, :project_id => 'ecookbook'
+
+    assert_response :success
+    assert_select '#pull_description', :text => /Pull request template example/
+  end
+
   #def test_show_with_repository
   #  get :show, :id => 1
   #


### PR DESCRIPTION
# Description

When creating a new pull request, lookup if a file `.redmine/PULL_REQUEST_TEMPLATE.(textile|md)` exists. If so, use it's content as a template for the description of the new pull request.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

1. Manually tested without a template
2. Manually tested with a template
3. A functional test was added

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
